### PR TITLE
Adds PostgreSQL charm integration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 In order to start developing and contributing to the FINOS Waltz Charmed Operator, make sure you have an environment in which you can deploy it. If you do not have one, you can create a Microk8s environment.
 
-Here is a [Local Deployment](docs/LocalDeployment.md) guide that will get you set up with a proper environment in which you can develop and deploy charms in. The guide also contains information on how to install Juju, bootstrap a Controller, create a Juju model, and create your own PostgreSQL database which will be needed by Waltz.
+Here is a [Local Deployment](docs/LocalDeployment.md) guide that will get you set up with a proper environment in which you can develop and deploy charms in. The guide also contains information on how to install Juju, bootstrap a Controller, create a Juju model, and deploy the `postgresql-k8s` charm and relate it to the Waltz charm.
 
 In addition to that, you will need to install Charmcraft, which we'll use to build the Charm. For more information on how to install Charmcraft, check the Charmcraft section of the [dev-setup](https://juju.is/docs/sdk/dev-setup)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ The Waltz Operator charm can be deployed by running:
 juju deploy finos-waltz-k8s --channel=edge
 ```
 
-The Waltz Operator charm will initially be in a Waiting state, it expects postgresql configurations to be set:
+The Waltz Operator charm will initially be in a Blocked state, it expects a PostgreSQL relation to be set:
+
+```
+juju deploy postgresql-k8s
+juju relate finos-waltz-k8s:db postgresql-k8s:db
+```
+
+Alternatively, it can be configured with an external PostgreSQL database connection details:
 
 ```bash
 juju config finos-waltz-k8s db-host="<db-host>" db-port="<db-port>" db-name="<db-name>" db-username="<db-username>" db-password="<db-password>"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,6 +11,12 @@ description: |
   In a nutshell, Waltz allows you to visualize and define your organisation's
   technology landscape. Think of it like a structured Wiki for your architecture.
 
+requires:
+  db:
+    interface: pgsql
+    limit: 1
+    scope: global
+
 containers:
   waltz:
     resource: waltz-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ops >= 1.2.0
+ops-lib-pgsql

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,9 +6,11 @@
 
 import logging
 
-from ops import charm, main, model, pebble
+from ops import charm, lib, main, model, pebble
 
 logger = logging.getLogger(__name__)
+
+pgsql = lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
 
 
 class WaltzOperatorCharm(charm.CharmBase):
@@ -21,9 +23,53 @@ class WaltzOperatorCharm(charm.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
+        # PostgreSQL relation hooks:
+        self.db = pgsql.PostgreSQLClient(self, "db")
+        self.framework.observe(
+            self.db.on.database_relation_joined, self._on_database_relation_joined
+        )
+        self.framework.observe(
+            self.db.on.database_relation_broken, self._on_database_relation_broken
+        )
+        self.framework.observe(self.db.on.master_changed, self._on_master_changed)
+
         # General hooks:
         self.framework.observe(self.on.waltz_pebble_ready, self._on_waltz_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+
+    def _on_database_relation_joined(self, event: pgsql.DatabaseRelationJoinedEvent):
+        """Handles the PostgreSQL database relation joined event.
+
+        When joining a relation with the PostgreSQL charm, we can request it to provision
+        us a database with a name chosen by us.
+        """
+        event.database = self.config["db-name"]
+
+    def _on_database_relation_broken(self, event: pgsql.DatabaseRelationBrokenEvent):
+        """Handles the PostgreSQL database relation broken event.
+
+        When the relation is broken, it means that we can no longer use the database it
+        provisioned us. Waltz will have to be updated to use the configured database instead,
+        if any.
+        """
+        self._rebuild_waltz_pebble_layer(event)
+
+    def _on_master_changed(self, event: pgsql.MasterChangedEvent):
+        """Handles the PostgreSQL database relation update event.
+
+        This event is generated whenever the PostgreSQL charm updates our relation with it,
+        including when it has provisioned the database we requested.
+        """
+        # Check if the requested database has been provided to us.
+        if event.database != self.config["db-name"]:
+            return
+
+        if event.master is None:
+            # There is no connection data.
+            return
+
+        # Update Waltz with the new database connection details.
+        self._rebuild_waltz_pebble_layer(event)
 
     def _on_waltz_pebble_ready(self, event):
         """Handles the Pebble Ready event."""
@@ -46,12 +92,6 @@ class WaltzOperatorCharm(charm.CharmBase):
         Waltz to connect to a postgresql database are present. The layer will
         only be recreated if it is different from the current specification.
         """
-        # Check if we have all the necessary information to start Waltz.
-        db_config = self._get_database_config()
-        if not db_config:
-            self.unit.status = model.BlockedStatus("Waiting for database configuration.")
-            return
-
         # If not provided with a container, get one.
         container = container or self.unit.get_container("waltz")
 
@@ -60,10 +100,19 @@ class WaltzOperatorCharm(charm.CharmBase):
             event.defer()
             return
 
+        # Check if we have all the necessary information to start Waltz.
+        db_config = self._get_database_config()
+        plan = container.get_plan()
+        if not db_config:
+            # If we don't have a database, make sure Waltz is not running (if it was started).
+            if "waltz" in plan.services:
+                container.stop("waltz")
+            self.unit.status = model.BlockedStatus("Waiting for database configuration.")
+            return
+
         # Create the current Pebble layer configuration
         pebble_layer = pebble.Layer(self._generate_workload_pebble_layer(db_config))
 
-        plan = container.get_plan()
         updated_services = plan.services != pebble_layer.services
         if updated_services:
             logger.info("Waltz needs to be updated. Restarting.")
@@ -78,6 +127,15 @@ class WaltzOperatorCharm(charm.CharmBase):
         Returns the configured database connection details as a dictionary. If they are
         missing, an empty dictionary is returned instead.
         """
+        # Check if we have a working relation with a PostgreSQL Server charm. If so, return the
+        # connection details to it.
+        db_relation = self.model.get_relation("db")
+        if db_relation and db_relation.units and db_relation.data[db_relation.app].get("master"):
+            # Expected format: 'host=foo.lish port=5432 dbname=waltz user=user password=pass'
+            pairs = db_relation.data[db_relation.app]["master"].split()
+            return dict([pair.split("=") for pair in pairs])
+
+        # We're not related to a PostgreSQL Server charm. Use the existing configuration.
         host = self.config["db-host"]
         port = self.config["db-port"]
         dbname = self.config["db-name"]
@@ -92,7 +150,7 @@ class WaltzOperatorCharm(charm.CharmBase):
             "host": host,
             "port": port,
             "dbname": dbname,
-            "username": username,
+            "user": username,
             "password": password,
         }
 
@@ -116,7 +174,7 @@ class WaltzOperatorCharm(charm.CharmBase):
                         "DB_HOST": db_config["host"],
                         "DB_PORT": db_config["port"],
                         "DB_NAME": db_config["dbname"],
-                        "DB_USER": db_config["username"],
+                        "DB_USER": db_config["user"],
                         "DB_PASSWORD": db_config["password"],
                         "DB_SCHEME": "waltz",
                         "WALTZ_FROM_EMAIL": "help@finos.org",

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -7,22 +7,88 @@ import unittest
 from unittest import mock
 
 from ops import model, testing
+from pgsql.opslib.pgsql import client
 
 import charm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
+        # Mock pgsql's leader data getter and setter.
+        self.leadership_data = {}
+        self._patch(client, "_get_pgsql_leader_data", self.leadership_data.copy)
+        self._patch(client, "_set_pgsql_leader_data", self.leadership_data.update)
+
         self.harness = testing.Harness(charm.WaltzOperatorCharm)
         self.addCleanup(self.harness.cleanup)
 
-    def _patch(self, obj, method):
+    def _patch(self, obj, method, *args, **kwargs):
         """Patches the given method and returns its Mock."""
-        patcher = mock.patch.object(obj, method)
+        patcher = mock.patch.object(obj, method, *args, **kwargs)
         mock_patched = patcher.start()
         self.addCleanup(patcher.stop)
 
         return mock_patched
+
+    def _add_relation(self, relation_name, relator_name, relation_data):
+        """Adds a relation to the charm."""
+        relation_id = self.harness.add_relation(relation_name, relator_name)
+        self.harness.add_relation_unit(relation_id, "%s/0" % relator_name)
+
+        self.harness.update_relation_data(relation_id, relator_name, relation_data)
+        return relation_id
+
+    def test_database_relation(self):
+        """Test for the PostgreSQL relation."""
+        # Setup mocks and start the initial hooks.
+        container = self.harness.model.unit.get_container("waltz")
+        self._patch(container, "stop")
+        mock_can_connect = self._patch(container, "can_connect")
+        mock_can_connect.return_value = True
+
+        # Setting the leader will allow the PostgreSQL charm to write relation data.
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        # Update the charm config, the charm should become Active.
+        self.harness.update_config({"db-host": "foo.lish"})
+        self.assertEqual(self.harness.model.unit.status, model.ActiveStatus())
+
+        # Check the service was started.
+        service = self.harness.model.unit.get_container("waltz").get_service("waltz")
+        self.assertTrue(service.is_running())
+
+        # Join a PostgreSQL charm. A database relation joined is then triggered. The database
+        # name should be set in the event.database. Without it, we can't continue on the
+        # master changed event.
+        rel_id = self._add_relation("db", "postgresql-charm", {})
+
+        # Update the relation data with a PostgreSQL connection string.
+        database_config = {
+            "db-host": "foo.lish",
+            "db-port": "5432",
+            "db-name": self.harness.charm.config["db-name"],
+            "db-username": "someuser",
+            "db-password": "somepass",
+        }
+        connection_url = "host=foo.lish port=5432 dbname=%s user=someuser password=somepass"
+        rel_data = {
+            "database": self.harness.charm.config["db-name"],
+            "master": connection_url % self.harness.charm.config["db-name"]
+        }
+        self.harness.update_relation_data(rel_id, "postgresql-charm", rel_data)
+
+        # Emit the master changed event.
+        relation = self.harness.model.get_relation("db")
+        unit = self.harness.charm.unit
+        self.harness.charm.db.on.master_changed.emit(relation, self.harness.charm.app, unit, unit)
+
+        # The Pebble plan should be updated with the PostgreSQL connection data from the relation.
+        self._check_pebble_plan(database_config)
+
+        # Remove the relation, and check that the Pebble plan is reverted to the previous config.
+        self.harness.remove_relation(rel_id)
+        self._check_pebble_plan(self.harness.charm.config)
 
     def test_waltz_pebble_ready(self):
         # Check the initial Pebble plan is empty
@@ -30,12 +96,16 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(initial_plan.to_yaml(), "{}\n")
 
         # Get the waltz container from the model and emit the PebbleReadyEvent carrying it.
-        self.harness.begin_with_initial_hooks()
         container = self.harness.model.unit.get_container("waltz")
+        mock_stop = self._patch(container, "stop")
+        self.harness.begin_with_initial_hooks()
         self.harness.charm.on.waltz_pebble_ready.emit(container)
 
-        # No datebase host was configured, so the status should be Waiting.
+        # No datebase host was configured, so the status should be Blocked.
         self.assertIsInstance(self.harness.model.unit.status, model.BlockedStatus)
+
+        # The service was not defined yet, as we did not have any database.
+        mock_stop.assert_not_called()
 
         # Update the charm config, and emit the PebbleReadyEvent again, but we can't
         # connect to the container yet.
@@ -55,7 +125,16 @@ class TestCharm(unittest.TestCase):
         service = self.harness.model.unit.get_container("waltz").get_service("waltz")
         self.assertTrue(service.is_running())
 
-        # Get the plan now we've run PebbleReady and check that we've got the plan we expected.
+        # Check that we've got the plan we expected.
+        self._check_pebble_plan(self.harness.charm.config)
+
+        # Emit the Pebble ready again, make sure that the container is NOT restarted if
+        # there was no configuration change.
+        mock_restart = self._patch(container, "restart")
+        self.harness.charm.on.waltz_pebble_ready.emit(container)
+        mock_restart.assert_not_called()
+
+    def _check_pebble_plan(self, expected_config):
         updated_plan = self.harness.get_container_pebble_plan("waltz").to_dict()
         expected_plan = {
             "services": {
@@ -66,11 +145,11 @@ class TestCharm(unittest.TestCase):
                     "startup": "enabled",
                     "user": "waltz",
                     "environment": {
-                        "DB_HOST": self.harness.charm.config["db-host"],
-                        "DB_PORT": self.harness.charm.config["db-port"],
-                        "DB_NAME": self.harness.charm.config["db-name"],
-                        "DB_USER": self.harness.charm.config["db-username"],
-                        "DB_PASSWORD": self.harness.charm.config["db-password"],
+                        "DB_HOST": expected_config["db-host"],
+                        "DB_PORT": expected_config["db-port"],
+                        "DB_NAME": expected_config["db-name"],
+                        "DB_USER": expected_config["db-username"],
+                        "DB_PASSWORD": expected_config["db-password"],
                         "DB_SCHEME": "waltz",
                         "WALTZ_FROM_EMAIL": "help@finos.org",
                         "CHANGELOG_FILE": "/opt/waltz/liquibase/db.changelog-master.xml",
@@ -80,20 +159,21 @@ class TestCharm(unittest.TestCase):
         }
         self.assertDictEqual(expected_plan, updated_plan)
 
-        # Emit the Pebble ready again, make sure that the container is NOT restarted if
-        # there was no configuration change.
-        mock_restart = self._patch(container, "restart")
-        self.harness.charm.on.waltz_pebble_ready.emit(container)
-        mock_restart.assert_not_called()
-
     def test_config_changed(self):
+        container = self.harness.model.unit.get_container("waltz")
+        mock_stop = self._patch(container, "stop")
         self.harness.begin_with_initial_hooks()
         self.assertIsInstance(self.harness.model.unit.status, model.BlockedStatus)
 
-        # Update the port, expect it to remain in WaitingStatus.
+        # Update the port, expect it to remain in BlockedStatus.
         self.harness.update_config({"db-port": 9999})
         self.assertIsInstance(self.harness.model.unit.status, model.BlockedStatus)
 
         # Update the host, expect it to become Active.
         self.harness.update_config({"db-host": "foo.lish"})
         self.assertEqual(self.harness.model.unit.status, model.ActiveStatus())
+
+        # Remove the db-host, and expect the container to be stopped.
+        self.harness.update_config({"db-host": ""})
+        self.assertIsInstance(self.harness.model.unit.status, model.BlockedStatus)
+        mock_stop.assert_called_once_with("waltz")


### PR DESCRIPTION
Updates the metadata.yaml file to include a database relation. Adds ops-lib-pgsql in requirements.txt, which we can use to handle the PostgreSQL Charm relation.

The Waltz charm will prioritize the PostgreSQL database provisioned to us by the charm. If there is no PostgreSQL charm relation, or if it was broken, the database connection details present in the Waltz Charm configuration will be used by Waltz instead.

Update the documentation to include information about the ``postgresql-k8s`` charm relation.